### PR TITLE
Add support for multi data-point selection

### DIFF
--- a/pbiviz.json
+++ b/pbiviz.json
@@ -4,7 +4,7 @@
     "displayName": "Waffle Chart",
     "guid": "WaffleChart1453776852267",
     "visualClassName": "Visual",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "A Waffle Chart uses a 10x10 grid of dots to visually show a percentage value. Each dot represents one percentage point, so a block of 43 highlighted dots would represent 43%. Multiple Waffle Charts can be used to visually compare multiple percentage values.",
     "supportUrl": "https://github.com/kiewic/PowerBI-WaffleChart",
     "gitHubUrl": "https://github.com/kiewic/PowerBI-WaffleChart"

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -402,10 +402,16 @@ module powerbi.extensibility.visual {
                 let index = category.identity.indexOf(d);
                 let selectionId = host.createSelectionIdBuilder().withCategory(category, index).createSelectionId();
 
-                selectionManager.select(selectionId).then(ids => {
+                let event = <MouseEvent>d3.event;
+                selectionManager.select(selectionId, event.ctrlKey || event.metaKey).then(ids => {
+                    let selectedElements = selection.filter(d => {
+                        let localIndex = category.identity.indexOf(d);
+                        let localId = host.createSelectionIdBuilder().withCategory(category, localIndex).createSelectionId();
+                        return ids.some((id: ISelectionId) => (<visuals.ISelectionId>id).equals(localId));
+                    });
                     if (ids.length > 0) {
                         selection.style('opacity', 0.4);
-                        d3.select(this).style('opacity', 1);
+                        selectedElements.style('opacity', 1);
                     } else {
                         selection.style('opacity', 1);
                     }


### PR DESCRIPTION
I tried to bind ISelectionId using `data(selectionId)`, but then
`ISelectionManager.select()` started failing, so I had to calculate
the `ISelectionId` later on the click handler before calling `select()`.

Another weird thing is the fact that `ids` is of type `extensibility.ISelectionId`
and I had to cast to `visuals.ISelectionId`.